### PR TITLE
add sasl plaintext to docker compose, without tls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,37 +4,66 @@ zookeeper_host = zookeeper:2181
 partition ?= 1
 replica ?= 1
 
+.PHONY: default
 default: help
 
+.PHONY: help
 help:
 	@echo 'Usage:'
 	@echo '    make help                 Show help'
 	@echo '    make start                Usage: make start'
+	@echo '    make start-sasl           Usage: make start-sasl'
+	@echo '    make status               Usage: make statu's
+	@echo '    make status-sasl          Usage: make status-sasl'
 	@echo '    make stop                 Usage: make stop'
+	@echo '    make stop-sasl            Usage: make stop-sasl'
 	@echo '    make attach               Usage: make attach'
 	@echo '    make create-topic         Usage: make create-topic topic={topic_name} partition={number} replica={number}'
 	@echo '    make list-topics          Usage: make list-topics'
-	@echo '    make describe-topic      Usage: make describe-topic topic={topic_name}'
+	@echo '    make describe-topic       Usage: make describe-topic topic={topic_name}'
 	@echo '    make delete-topic         Usage: make delete-topic topic={topic_name}'
 
+.PHONY: start
 start:
-	@docker-compose up -d
+	@docker-compose -f docker-compose.yml up -d
 
+.PHONY: start-sasl
+start-sasl:
+	@docker-compose -f docker-compose-sasl.yml up -d
+
+.PHONY: status
+status:
+	@docker-compose -f docker-compose.yml ps
+
+.PHONY: status-sasl
+status-sasl:
+	@docker-compose -f docker-compose-sasl.yml ps
+
+.PHONY: stop
 stop:
-	@docker-compose down
+	@docker-compose -f docker-compose.yml down
 
+.PHONY: stop-sasl
+stop-sasl:
+	@docker-compose -f docker-compose-sasl.yml down
+
+.PHONY: attach
 attach:
 	@./attach_kafka.sh
 
+.PHONY: create-topic
 create-topic:
 	@docker exec kafka_2.12-2.3.0 kafka-topics.sh --create --topic $(topic)  -zookeeper ${zookeeper_host} --partitions $(partition) --replication-factor $(replica)
 
+.PHONY: list
 list-topics:
 	@docker exec kafka_2.12-2.3.0 kafka-topics.sh --list --zookeeper ${zookeeper_host}
 
+.PHONY: describe-topic
 describe-topic:
 	@docker exec kafka_2.12-2.3.0 kafka-topics.sh --describe --topic $(topic) --zookeeper ${zookeeper_host}
 
+.PHONY: delete-topic
 delete-topic:
 	@docker exec kafka_2.12-2.3.0 kafka-topics.sh --zookeeper ${zookeeper_host} --delete --topic $(topic)
 

--- a/README.md
+++ b/README.md
@@ -11,21 +11,12 @@ Dockerfile for [Apache Kafka](http://kafka.apache.org/)
 
 The image is available directly from [Docker Hub](https://hub.docker.com/r/wurstmeister/kafka/)
 
+_**Note** : This a modified version version of [wurstmeister/kafka-docker](https://github.com/wurstmeister/kafka-docker) library with an additional feature. Please refer to the original repo for the original features._
+
 Tags and releases
 -----------------
 
-All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
-
-- `2.12-2.3.0`
-- `2.12-2.2.1`
-- `2.12-2.1.1`
-- `2.12-2.0.1`
-- `2.11-1.1.1`
-- `2.11-1.0.2`
-- `2.11-0.11.0.3`
-- `2.11-0.10.2.2`
-- `2.11-0.9.0.1`
-- `2.10-0.8.2.2`
+All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags can be seen [here](https://hub.docker.com/r/wurstmeister/kafka/tags).
 
 Everytime the image is updated, all tags will be pushed with the latest updates. This should allow for greater consistency across tags, as well as any security updates that have been made to the base image.
 

--- a/docker-compose-sasl.yml
+++ b/docker-compose-sasl.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  zookeeper:
+    image: zookeeper:3.6.1
+    container_name: zookeeper_3.6.1_sasl
+    mem_limit: 1g
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:2.12-2.5.0
+    container_name: kafka_2.12-2.5.0_sasl
+    mem_limit: 1g
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: SASL_PLAINTEXT://:9092
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://localhost:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf"
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./overrides/kafka/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
+    links:
+      - zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
 version: '2'
 services:
   zookeeper:
-    image: wurstmeister/zookeeper
-    container_name: zookeeper_latest
+    image: zookeeper:3.6.1
+    container_name: zookeeper_3.6.1
     mem_limit: 1g
     ports:
       - "2181:2181"
+
   kafka:
-    image: wurstmeister/kafka:2.12-2.3.0
-    container_name: kafka_2.12-2.3.0
+    image: wurstmeister/kafka:2.12-2.5.0
+    container_name: kafka_2.12-2.5.0
     mem_limit: 1g
     ports:
       - "9092:9092"
@@ -17,3 +18,5 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - zookeeper

--- a/overrides/kafka/kafka_server_jaas.conf
+++ b/overrides/kafka/kafka_server_jaas.conf
@@ -1,0 +1,8 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret"
+  user_alice="alice-secret";
+};
+Client {};


### PR DESCRIPTION
## What I do
- add sasl plain mode if you want to run kafka with sasl (no tls required)

## Usage

Start kafka
```bash
$ make start-sasl
```

See kafka status
```bash
$ make status-sasl
```

Stop kafka
```bash
$ make stop-sasl
```